### PR TITLE
운동 조회 엔드포인트 추가

### DIFF
--- a/src/main/java/com/levelupfit/mainbackend/controller/ExercisesController.java
+++ b/src/main/java/com/levelupfit/mainbackend/controller/ExercisesController.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @CrossOrigin(origins = "http://localhost:4000")
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +23,26 @@ public class ExercisesController {
         if(responseDTO.isSuccess()) {
             return ResponseEntity.ok(responseDTO);
         } else {
+            return ResponseEntity.badRequest().body(responseDTO);
+        }
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ExerciseDTO>>> getExercise() {
+        ApiResponse<List<ExerciseDTO>> responseDTO = exerciseService.ExerciseFindAll();
+        if(responseDTO.isSuccess()) {
+            return ResponseEntity.ok(responseDTO);
+        } else {
+            return ResponseEntity.badRequest().body(responseDTO);
+        }
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<ExerciseDTO>> getExerciseById(@PathVariable int id) {
+        ApiResponse<ExerciseDTO> responseDTO = exerciseService.ExerciseFindById(id);
+        if(responseDTO.isSuccess()) {
+            return ResponseEntity.ok(responseDTO);
+        } else{
             return ResponseEntity.badRequest().body(responseDTO);
         }
     }

--- a/src/main/java/com/levelupfit/mainbackend/dto/exercise/ExerciseDTO.java
+++ b/src/main/java/com/levelupfit/mainbackend/dto/exercise/ExerciseDTO.java
@@ -1,5 +1,6 @@
 package com.levelupfit.mainbackend.dto.exercise;
 
+import com.levelupfit.mainbackend.domain.exercise.Exercise;
 import lombok.Data;
 
 @Data
@@ -10,5 +11,29 @@ public class ExerciseDTO {
     private String thumbnailUrl;
     private String targetMuscle;
     private Boolean feedbackAvailable;
+
+    public ExerciseDTO() {
+
+    }
+
+    public ExerciseDTO(int id, String name, String description, String thumbnailUrl, String targetMuscle, Boolean feedbackAvailable) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.thumbnailUrl = thumbnailUrl;
+        this.targetMuscle = targetMuscle;
+        this.feedbackAvailable = feedbackAvailable;
+    }
+
+    public static ExerciseDTO fromExercise(Exercise exercise) {
+        return new ExerciseDTO(
+                exercise.getExerciseId(),
+                exercise.getName(),
+                exercise.getDescription(),
+                exercise.getThumbnailUrl(),
+                exercise.getTargetMuscle(),
+                exercise.isFeedbackAvailable()
+        );
+    }
 
 }

--- a/src/main/java/com/levelupfit/mainbackend/repository/ExerciseRepository.java
+++ b/src/main/java/com/levelupfit/mainbackend/repository/ExerciseRepository.java
@@ -3,6 +3,8 @@ package com.levelupfit.mainbackend.repository;
 import com.levelupfit.mainbackend.domain.exercise.Exercise;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ExerciseRepository extends JpaRepository<Exercise, Integer> {
+import java.util.Optional;
 
+public interface ExerciseRepository extends JpaRepository<Exercise, Integer> {
+    Exercise findById(int id);
 }

--- a/src/main/java/com/levelupfit/mainbackend/service/ExerciseService.java
+++ b/src/main/java/com/levelupfit/mainbackend/service/ExerciseService.java
@@ -8,13 +8,16 @@ import com.levelupfit.mainbackend.repository.ExerciseRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class ExerciseService {
     private final ExerciseRepository exerciseRepository;
 
+    //운동 생성
     public ApiResponse<ExerciseDTO> ExerciseCreate(ExerciseCreateRequest exerciseDTO) {
-        //create 구현중
         try{
             Exercise exercise = Exercise.builder()
                     .name(exerciseDTO.getName())
@@ -44,4 +47,30 @@ public class ExerciseService {
 
         }
     }
+    
+    //운동 조회
+    public ApiResponse<List<ExerciseDTO>> ExerciseFindAll() {
+        try{
+            List<ExerciseDTO> list = exerciseRepository.findAll()
+                    .stream()
+                    .map(ExerciseDTO::fromExercise) // Entity -> DTO로 변환
+                    .toList(); //List로 변환
+            return ApiResponse.ok(list, 200);
+        } catch (Exception e){
+            return ApiResponse.fail("운동 조회중 오류발생",500);
+        }
+    }
+
+    //운동 단일 조회
+    public ApiResponse<ExerciseDTO> ExerciseFindById(int id) {
+        try{
+            Exercise exercise = exerciseRepository.findById(id);
+            ExerciseDTO dto = ExerciseDTO.fromExercise(exercise);
+            return ApiResponse.ok(dto, 200);
+        } catch (Exception e){
+            return ApiResponse.fail("운동 조회중 오류발생",500);
+        }
+
+    }
+    
 }


### PR DESCRIPTION
운동 조회 기능 구현:
- 전체 운동 목록 및 ID 기반 단일 운동 조회를 위한 엔드포인트 추가
- Exercise 엔티티를 DTO로 변환하는 메서드 작성
- findById 메서드를 repository에 추가하여 단일 조회 지원