### PR TITLE
기본 루틴 및 사용자 루틴 조회 엔드포인트 추가

### DIFF
--- a/src/main/java/com/levelupfit/mainbackend/controller/RoutineController.java
+++ b/src/main/java/com/levelupfit/mainbackend/controller/RoutineController.java
@@ -1,9 +1,14 @@
 package com.levelupfit.mainbackend.controller;
 
+import com.levelupfit.mainbackend.dto.ApiResponse;
+import com.levelupfit.mainbackend.dto.routine.RoutineDTO;
+import com.levelupfit.mainbackend.service.RoutineService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @CrossOrigin(origins = "http://localhost:4000")
 @Controller
@@ -11,4 +16,26 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("routine")
 public class RoutineController {
 
+    private final RoutineService routineService;
+
+    //userId로 조회
+    @GetMapping("/{userid}")
+    public ResponseEntity<ApiResponse<List<RoutineDTO>>> getRoutine(@PathVariable Integer userid) {
+        ApiResponse<List<RoutineDTO>> response = routineService.getRoutineByUserId(userid);
+        if(response.isSuccess()) {
+            return ResponseEntity.ok(response);
+        } else{
+            return ResponseEntity.badRequest().body(response);
+        }
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<RoutineDTO>>> getRoutinesDefault() {
+        ApiResponse<List<RoutineDTO>> response = routineService.getRoutineDefault();
+        if(response.isSuccess()) {
+            return ResponseEntity.ok(response);
+        } else{
+            return ResponseEntity.badRequest().body(response);
+        }
+    }
 }

--- a/src/main/java/com/levelupfit/mainbackend/domain/routine/Routine.java
+++ b/src/main/java/com/levelupfit/mainbackend/domain/routine/Routine.java
@@ -19,8 +19,8 @@ public class Routine {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int routineId;
 
-    @JoinColumn(name = "user_id")
-    private int userId;
+    @Column(name = "user_id")
+    private Integer userId;
 
     @Column(nullable = false)
     private String name;

--- a/src/main/java/com/levelupfit/mainbackend/dto/routine/RoutineDTO.java
+++ b/src/main/java/com/levelupfit/mainbackend/dto/routine/RoutineDTO.java
@@ -1,0 +1,37 @@
+package com.levelupfit.mainbackend.dto.routine;
+
+import com.levelupfit.mainbackend.domain.routine.Routine;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class RoutineDTO {
+    private int routineId;
+    private Integer userId;
+    private String name;
+    private String description;
+    private int difficulty;
+    private LocalDate createdAt;
+
+    public RoutineDTO(int routineId, Integer userId, String name, String description, int difficulty, LocalDate createdAt) {
+        this.routineId = routineId;
+        this.userId = userId;
+        this.name = name;
+        this.description = description;
+        this.difficulty = difficulty;
+        this.createdAt = createdAt;
+    }
+
+    //entitiy -> DTO 메서드
+    public static RoutineDTO fromRoutine(Routine routine) {
+        return new RoutineDTO(
+                routine.getRoutineId(),
+                routine.getUserId(),
+                routine.getName(),
+                routine.getDescription(),
+                routine.getDifficulty(),
+                routine.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/levelupfit/mainbackend/repository/RoutineRepository.java
+++ b/src/main/java/com/levelupfit/mainbackend/repository/RoutineRepository.java
@@ -3,6 +3,10 @@ package com.levelupfit.mainbackend.repository;
 import com.levelupfit.mainbackend.domain.routine.Routine;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RoutineRepository extends JpaRepository<Routine, Integer> {
+import java.util.List;
 
+public interface RoutineRepository extends JpaRepository<Routine, Integer> {
+    List<Routine> findByUserId(Integer userId);
+    List<Routine> findByUserIdIsNull();
+    List<Routine> findByRoutineId(int routineId);
 }

--- a/src/main/java/com/levelupfit/mainbackend/service/RoutineService.java
+++ b/src/main/java/com/levelupfit/mainbackend/service/RoutineService.java
@@ -1,10 +1,43 @@
 package com.levelupfit.mainbackend.service;
 
+import com.levelupfit.mainbackend.dto.ApiResponse;
+import com.levelupfit.mainbackend.dto.routine.RoutineDTO;
+import com.levelupfit.mainbackend.repository.RoutineRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class RoutineService {
 
+    private final RoutineRepository routineRepository;
+
+    //유저 ID로 루틴 조회
+    public ApiResponse<List<RoutineDTO>> getRoutineByUserId(Integer userid) {
+        try{
+            List<RoutineDTO> list = routineRepository.findByUserId(userid)
+                    .stream()
+                    .map(RoutineDTO::fromRoutine)
+                    .toList();
+
+            return ApiResponse.ok(list,200);
+        } catch (Exception e){
+            return ApiResponse.fail("루틴 조회중 오류가 발생하였습니다",500);
+        }
+    }
+
+    //기본 루틴 조회
+    public ApiResponse<List<RoutineDTO>> getRoutineDefault() {
+        try{
+            List<RoutineDTO> list = routineRepository.findByUserIdIsNull()
+                    .stream()
+                    .map(RoutineDTO::fromRoutine)
+                    .toList();
+            return ApiResponse.ok(list,200);
+        } catch (Exception e){
+            return ApiResponse.fail("루틴 조회중 오류 발생",500);
+        }
+    }
 }


### PR DESCRIPTION
- 기본 루틴 조회를 위한 GET /routines/default 엔드포인트 구현
- 사용자별 루틴 조회를 위한 GET /routines?userId={id} 엔드포인트 구현
- 루틴 정보를 전달하기 위한 RoutineDTO 생성
- RoutineRepository에 userId 기반 조회 및 공용 루틴 조회 메서드 추가
